### PR TITLE
feat(room): 방 생성/조회/태그 조회 API 및 React Query 훅 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 // app/layout.tsx
 import Providers from "./providers";
+import "./globals.css";
 
 export default function RootLayout({
   children,

--- a/src/app/room/[slug]/page.tsx
+++ b/src/app/room/[slug]/page.tsx
@@ -1,9 +1,9 @@
-"use client";
+type Props = {
+  params: Promise<{ slug: string }>;
+};
 
-import { useParams } from "next/navigation";
+export default async function RoomPage({ params }: Props) {
+  const { slug } = await params;
 
-export default function RoomPage() {
-  const params = useParams<{ slug: string }>();
-
-  return <div>room: {params.slug}</div>;
+  return <div>room: {slug}</div>;
 }

--- a/src/app/room/[slug]/page.tsx
+++ b/src/app/room/[slug]/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+export default function RoomPage() {
+  const params = useParams<{ slug: string }>();
+
+  return <div>room: {params.slug}</div>;
+}

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -6,6 +6,8 @@ import NicknameEditForm from "@/src/features/user-profile/ui/NicknameEditForm";
 import { useRouter } from "next/navigation";
 import IsLogin from "@/src/entities/user/ui/IsLogin";
 import RoomTags from "@/src/entities/room/ui/RoomTags";
+import CreateRoomTest from "@/src/features/room/create/ui/CreateRoomTest";
+import RoomsListTest from "@/src/entities/room/ui/RoomListTest";
 
 export default function TestPage() {
   const router = useRouter();
@@ -17,8 +19,15 @@ export default function TestPage() {
       <NicknameEditForm />
       <IsLogin />
       <RoomTags />
+      <CreateRoomTest />
+      <RoomsListTest />
 
-      <button onClick={() => router.push("/home")}>go to home page</button>
+      <button
+        onClick={() => router.push("/home")}
+        className="border cursor-pointer"
+      >
+        go to home page
+      </button>
     </div>
   );
 }

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import GoogleLoginButton from "@/src/features/auth/login-with-google/ui/googleLoginButton";
-import { useMe } from "@/src/entities/user/hooks/useMe";
 import LogoutButton from "@/src/features/auth/logout/ui/logoutButton";
 import NicknameEditForm from "@/src/features/user-profile/ui/NicknameEditForm";
 import { useRouter } from "next/navigation";
+import IsLogin from "@/src/entities/user/ui/IsLogin";
+import RoomTags from "@/src/entities/room/ui/RoomTags";
 
 export default function TestPage() {
-  const { data: me, isError, error } = useMe();
-
   const router = useRouter();
 
   return (
@@ -16,12 +15,9 @@ export default function TestPage() {
       <GoogleLoginButton />
       <LogoutButton />
       <NicknameEditForm />
+      <IsLogin />
+      <RoomTags />
 
-      <div className="border p-3">
-        {isError && <div>me 실패: {String((error as Error)?.message)}</div>}
-        {me && <pre>{JSON.stringify(me, null, 2)}</pre>}
-        {me === null && <div>로그인 필요</div>}
-      </div>
       <button onClick={() => router.push("/home")}>go to home page</button>
     </div>
   );

--- a/src/entities/room/api/createRoom.ts
+++ b/src/entities/room/api/createRoom.ts
@@ -1,5 +1,12 @@
 import { axiosInstance } from "@/src/shared/api/axiosInstance";
+import { CreateRoomPayload } from "./types";
 
-export async function createRoom() {
-  const res = await axiosInstance.post("/api/v1/rooms");
+type ApiResponse<T> = { result: T };
+
+export async function createRoom(payload: CreateRoomPayload): Promise<boolean> {
+  const res = await axiosInstance.post<ApiResponse<boolean>>(
+    "/api/v1/rooms",
+    payload
+  );
+  return res.data.result;
 }

--- a/src/entities/room/api/createRoom.ts
+++ b/src/entities/room/api/createRoom.ts
@@ -1,0 +1,5 @@
+import { axiosInstance } from "@/src/shared/api/axiosInstance";
+
+export async function createRoom() {
+  const res = await axiosInstance.post("/api/v1/rooms");
+}

--- a/src/entities/room/api/createRoom.ts
+++ b/src/entities/room/api/createRoom.ts
@@ -1,12 +1,24 @@
 import { axiosInstance } from "@/src/shared/api/axiosInstance";
-import { CreateRoomPayload } from "./types";
+import type { ApiResponse } from "@/src/shared/api/types";
+import { ApiError } from "@/src/shared/api/api-error";
+import type { CreateRoomPayload, CreateRoomResult } from "./types";
 
-type ApiResponse<T> = { result: T };
-
-export async function createRoom(payload: CreateRoomPayload): Promise<boolean> {
+export async function createRoom(
+  payload: CreateRoomPayload
+): Promise<CreateRoomResult> {
   const res = await axiosInstance.post<ApiResponse<boolean>>(
     "/api/v1/rooms",
     payload
   );
-  return res.data.result;
+
+  const slug = (res.headers?.location as string | undefined) ?? undefined;
+
+  if (!slug) {
+    throw new ApiError({
+      status: res.status,
+      message: "Location 헤더가 없어 방으로 이동할 수 없습니다.",
+    });
+  }
+
+  return { slug };
 }

--- a/src/entities/room/api/fetchRooms.ts
+++ b/src/entities/room/api/fetchRooms.ts
@@ -1,7 +1,6 @@
 import { axiosInstance } from "@/src/shared/api/axiosInstance";
 import type { RoomsResponse } from "../model/types";
-
-type ApiResponse<T> = { result: T };
+import { ApiResponse } from "@/src/shared/api/types";
 
 export async function fetchRooms(): Promise<RoomsResponse> {
   const res = await axiosInstance.get<ApiResponse<RoomsResponse>>(

--- a/src/entities/room/api/fetchRooms.ts
+++ b/src/entities/room/api/fetchRooms.ts
@@ -1,0 +1,11 @@
+import { axiosInstance } from "@/src/shared/api/axiosInstance";
+import type { RoomsResponse } from "../model/types";
+
+type ApiResponse<T> = { result: T };
+
+export async function fetchRooms(): Promise<RoomsResponse> {
+  const res = await axiosInstance.get<ApiResponse<RoomsResponse>>(
+    "/api/v1/rooms"
+  );
+  return res.data.result;
+}

--- a/src/entities/room/api/fetchTags.ts
+++ b/src/entities/room/api/fetchTags.ts
@@ -1,0 +1,11 @@
+import { axiosInstance } from "@/src/shared/api/axiosInstance";
+import type { RoomTag } from "../model/types";
+
+type ApiResponse<T> = { result: T };
+
+export async function fetchRoomTags(): Promise<RoomTag[]> {
+  const res = await axiosInstance.get<ApiResponse<{ tags: RoomTag[] }>>(
+    "/api/v1/tags"
+  );
+  return res.data.result.tags;
+}

--- a/src/entities/room/api/fetchTags.ts
+++ b/src/entities/room/api/fetchTags.ts
@@ -7,5 +7,6 @@ export async function fetchRoomTags(): Promise<RoomTag[]> {
   const res = await axiosInstance.get<ApiResponse<{ tags: RoomTag[] }>>(
     "/api/v1/tags"
   );
+
   return res.data.result.tags;
 }

--- a/src/entities/room/api/fetchTags.ts
+++ b/src/entities/room/api/fetchTags.ts
@@ -1,7 +1,6 @@
 import { axiosInstance } from "@/src/shared/api/axiosInstance";
 import type { RoomTag } from "../model/types";
-
-type ApiResponse<T> = { result: T };
+import { ApiResponse } from "@/src/shared/api/types";
 
 export async function fetchRoomTags(): Promise<RoomTag[]> {
   const res = await axiosInstance.get<ApiResponse<{ tags: RoomTag[] }>>(

--- a/src/entities/room/api/types.ts
+++ b/src/entities/room/api/types.ts
@@ -1,0 +1,5 @@
+export type CreateRoomPayload = {
+  title: string;
+  password?: string;
+  tags?: string[];
+};

--- a/src/entities/room/api/types.ts
+++ b/src/entities/room/api/types.ts
@@ -3,3 +3,7 @@ export type CreateRoomPayload = {
   password?: string;
   tags?: string[];
 };
+
+export type CreateRoomResult = {
+  slug: string;
+};

--- a/src/entities/room/hooks/useFetchRooms.ts
+++ b/src/entities/room/hooks/useFetchRooms.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchRooms } from "../api/fetchRooms";
+import type { RoomsResponse } from "../model/types";
+import type { ApiError } from "@/src/shared/api/api-error";
+
+export function useRoomsQuery() {
+  return useQuery<RoomsResponse, ApiError>({
+    queryKey: ["rooms"],
+    queryFn: fetchRooms,
+    retry: false,
+  });
+}

--- a/src/entities/room/hooks/useRoomTags.ts
+++ b/src/entities/room/hooks/useRoomTags.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchRoomTags } from "../api/fetchTags";
+
+export function useRoomTags() {
+  return useQuery({
+    queryKey: ["roomTags"],
+    queryFn: fetchRoomTags,
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+}

--- a/src/entities/room/model/types.ts
+++ b/src/entities/room/model/types.ts
@@ -8,7 +8,7 @@ export type Room = {
   slug: string;
   title: string;
   isPrivate: boolean;
-  createAt: string;
+  createdAt: string;
   tags: RoomTag[];
 };
 

--- a/src/entities/room/model/types.ts
+++ b/src/entities/room/model/types.ts
@@ -1,0 +1,18 @@
+export type RoomTag = {
+  slug: string;
+  name: string;
+};
+
+export type Room = {
+  id: number;
+  slug: string;
+  title: string;
+  isPrivate: boolean;
+  createAt: string;
+  tags: RoomTag[];
+};
+
+export type RoomsResponse = {
+  rooms: Room[];
+  hasNext: boolean;
+};

--- a/src/entities/room/ui/RoomListTest.tsx
+++ b/src/entities/room/ui/RoomListTest.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useRoomsQuery } from "../hooks/useFetchRooms";
+
+export default function RoomsListTest() {
+  const { data, isLoading, isError, error } = useRoomsQuery();
+
+  if (isLoading)
+    return <div className="border p-4 text-black">방 목록 로딩중...</div>;
+
+  if (isError) {
+    return (
+      <div className="border p-4 text-black">
+        방 목록 로딩 실패: ({error.status}) {error.message}
+      </div>
+    );
+  }
+
+  const rooms = data?.rooms ?? [];
+
+  return (
+    <div className="border p-4 space-y-3 text-black">
+      <div className="text-sm font-semibold">방 목록 테스트</div>
+
+      {rooms.length === 0 ? (
+        <div className="text-sm">방이 없습니다.</div>
+      ) : (
+        <ul className="space-y-2">
+          {rooms.map((room) => (
+            <li key={room.id} className="border p-3 space-y-1">
+              <div className="text-sm">
+                <span className="font-semibold">제목:</span> {room.title}
+              </div>
+
+              <div className="text-sm">
+                <span className="font-semibold">슬러그:</span> {room.slug}
+              </div>
+
+              <div className="text-sm">
+                <span className="font-semibold">태그:</span>{" "}
+                {room.tags?.length ? (
+                  room.tags.map((t) => t.name).join(", ")
+                ) : (
+                  <span className="text-gray-600">없음</span>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/entities/room/ui/RoomListTest.tsx
+++ b/src/entities/room/ui/RoomListTest.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import JoinRoomButton from "@/src/features/room/join/JoinRoomButton";
 import { useRoomsQuery } from "../hooks/useFetchRooms";
 
 export default function RoomsListTest() {
@@ -44,6 +45,7 @@ export default function RoomsListTest() {
                   <span className="text-gray-600">없음</span>
                 )}
               </div>
+              <JoinRoomButton slug={room.slug} />
             </li>
           ))}
         </ul>

--- a/src/entities/room/ui/RoomTags.tsx
+++ b/src/entities/room/ui/RoomTags.tsx
@@ -1,0 +1,22 @@
+import { useRoomTags } from "../hooks/useRoomTags";
+
+export default function RoomTags() {
+  const { data, isLoading, isError } = useRoomTags();
+
+  if (isLoading) return <div>태그 로딩중...</div>;
+  if (isError) return <div>태그 로딩 실패</div>;
+
+  const tags = data ?? [];
+
+  console.log("roomTags data:", data);
+
+  return (
+    <div className="flex flex-wrap gap-2 text-black">
+      {tags.map((tag) => (
+        <span key={tag.slug} className="px-2 py-1 rounded-md border text-sm">
+          {tag.name}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/entities/user/api/me.ts
+++ b/src/entities/user/api/me.ts
@@ -1,8 +1,7 @@
 // src/entities/user/api/me.ts
 import { axiosInstance } from "@/src/shared/api/axiosInstance";
 import type { User } from "../model/types";
-
-type ApiResponse<T> = { result: T };
+import { ApiResponse } from "@/src/shared/api/types";
 
 export async function fetchMe(): Promise<User> {
   const { data } = await axiosInstance.get<ApiResponse<User>>(

--- a/src/entities/user/api/onboarding.ts
+++ b/src/entities/user/api/onboarding.ts
@@ -1,7 +1,6 @@
 import { axiosInstance } from "@/src/shared/api/axiosInstance";
 import type { OnboardingPayload } from "../model/types";
-
-type ApiResponse<T> = { result: T };
+import { ApiResponse } from "@/src/shared/api/types";
 
 export async function completeOnboarding(
   payload: OnboardingPayload

--- a/src/entities/user/hooks/useMe.ts
+++ b/src/entities/user/hooks/useMe.ts
@@ -3,9 +3,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { User } from "../model/types";
 import { fetchMe } from "../api/me";
+import { ApiError } from "@/src/shared/api/api-error";
 
 export function useMe() {
-  return useQuery<User | null>({
+  return useQuery<User | null, ApiError>({
     queryKey: ["me"],
     queryFn: fetchMe,
     staleTime: 0,

--- a/src/entities/user/ui/IsLogin.tsx
+++ b/src/entities/user/ui/IsLogin.tsx
@@ -4,10 +4,14 @@ export default function IsLogin() {
   const { data: me, isError, error, isLoading } = useMe();
 
   return (
-    <div className="border p-3">
+    <div className="border p-3 text-black">
       {isLoading && <div>me 로딩중...</div>}
 
-      {isError && <div>me 실패: {String((error as Error)?.message)}</div>}
+      {isError && (
+        <div>
+          me 실패: ({error.status}) {error.message}
+        </div>
+      )}
 
       {me && <pre>{JSON.stringify(me, null, 2)}</pre>}
 

--- a/src/entities/user/ui/IsLogin.tsx
+++ b/src/entities/user/ui/IsLogin.tsx
@@ -4,11 +4,11 @@ export default function IsLogin() {
   const { data: me, isError, error, isLoading } = useMe();
 
   return (
-    <div className="border p-3 text-black">
+    <div className=" text-black">
       {isLoading && <div>me 로딩중...</div>}
 
       {isError && (
-        <div>
+        <div className="text-sm text-red-600">
           me 실패: ({error.status}) {error.message}
         </div>
       )}

--- a/src/entities/user/ui/IsLogin.tsx
+++ b/src/entities/user/ui/IsLogin.tsx
@@ -1,0 +1,17 @@
+import { useMe } from "../hooks/useMe";
+
+export default function IsLogin() {
+  const { data: me, isError, error, isLoading } = useMe();
+
+  return (
+    <div className="border p-3">
+      {isLoading && <div>me 로딩중...</div>}
+
+      {isError && <div>me 실패: {String((error as Error)?.message)}</div>}
+
+      {me && <pre>{JSON.stringify(me, null, 2)}</pre>}
+
+      {me === null && <div>로그인 필요</div>}
+    </div>
+  );
+}

--- a/src/features/auth/login-with-google/ui/googleLoginButton.tsx
+++ b/src/features/auth/login-with-google/ui/googleLoginButton.tsx
@@ -4,7 +4,10 @@ import { redirectToGoogleLogin } from "../api/login";
 
 export default function GoogleLogionButton() {
   return (
-    <button className="border" onClick={() => redirectToGoogleLogin()}>
+    <button
+      className="border cursor-pointer mx-2"
+      onClick={() => redirectToGoogleLogin()}
+    >
       구글 로그인
     </button>
   );

--- a/src/features/auth/logout/ui/logoutButton.tsx
+++ b/src/features/auth/logout/ui/logoutButton.tsx
@@ -6,7 +6,11 @@ export default function LogoutButton() {
   const { mutate: logout, isPending } = useLogout();
 
   return (
-    <button className="border" onClick={() => logout()} disabled={isPending}>
+    <button
+      className="border cursor-pointer"
+      onClick={() => logout()}
+      disabled={isPending}
+    >
       {isPending ? "로그아웃 중..." : "로그아웃"}
     </button>
   );

--- a/src/features/room/create/model/useCreateRoom.ts
+++ b/src/features/room/create/model/useCreateRoom.ts
@@ -3,16 +3,21 @@
 import { createRoom } from "@/src/entities/room/api/createRoom";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { ApiError } from "@/src/shared/api/api-error";
-import type { CreateRoomPayload } from "@/src/entities/room/api/types";
+import type {
+  CreateRoomPayload,
+  CreateRoomResult,
+} from "@/src/entities/room/api/types";
+import { useRouter } from "next/navigation";
 
 export function useCreateRoom() {
   const qc = useQueryClient();
+  const router = useRouter();
 
-  return useMutation<boolean, ApiError, CreateRoomPayload>({
+  return useMutation<CreateRoomResult, ApiError, CreateRoomPayload>({
     mutationFn: createRoom,
-    onSuccess: async () => {
+    onSuccess: async (result) => {
       await qc.invalidateQueries({ queryKey: ["rooms"] });
-      // TODO: room으로 이동
+      router.push(`/room/${result.slug}`);
     },
   });
 }

--- a/src/features/room/create/model/useCreateRoom.ts
+++ b/src/features/room/create/model/useCreateRoom.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { createRoom } from "@/src/entities/room/api/createRoom";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { ApiError } from "@/src/shared/api/api-error";
+import type { CreateRoomPayload } from "@/src/entities/room/api/types";
+
+export function useCreateRoom() {
+  const qc = useQueryClient();
+
+  return useMutation<boolean, ApiError, CreateRoomPayload>({
+    mutationFn: createRoom,
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ["rooms"] });
+      // TODO: room으로 이동
+    },
+  });
+}

--- a/src/features/room/create/ui/CreateRoomTest.tsx
+++ b/src/features/room/create/ui/CreateRoomTest.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { useCreateRoom } from "@/src/features/room/create/model/useCreateRoom";
+
+export default function CreateRoomTest() {
+  const { mutate, isPending, error, data } = useCreateRoom();
+
+  const [title, setTitle] = useState("");
+  const [password, setPassword] = useState(""); // optional
+  const [tagSlug, setTagSlug] = useState("lo-fi"); // tags: ["lo-fi"]
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const t = title.trim();
+    if (!t) return;
+
+    mutate({
+      title: t,
+      password: password.trim() ? password.trim() : undefined,
+      tags: tagSlug.trim() ? [tagSlug.trim()] : [],
+    });
+  };
+
+  return (
+    <div className="border p-4 space-y-3 text-black">
+      <div className="text-sm font-semibold">방 생성 테스트</div>
+
+      <form onSubmit={onSubmit} className="space-y-2">
+        <div className="space-y-1">
+          <label className="block text-xs">title</label>
+          <input
+            className="border px-2 py-1 w-full"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="새벽 코딩 달리실 분"
+            disabled={isPending}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label className="block text-xs">password (optional)</label>
+          <input
+            className="border px-2 py-1 w-full"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="1234"
+            disabled={isPending}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <label className="block text-xs">tag slug</label>
+          <input
+            className="border px-2 py-1 w-full"
+            value={tagSlug}
+            onChange={(e) => setTagSlug(e.target.value)}
+            placeholder="lo-fi"
+            disabled={isPending}
+          />
+        </div>
+
+        <button
+          type="submit"
+          className="border px-3 py-1 cursor-pointer"
+          disabled={isPending}
+        >
+          {isPending ? "생성 중..." : "방 생성"}
+        </button>
+      </form>
+
+      {error && (
+        <div className="text-sm text-red-600">
+          생성 실패: ({error.status}) {error.message}
+        </div>
+      )}
+
+      {/* createRoom이 boolean을 반환한다는 전제 */}
+      {data !== undefined && (
+        <div className="text-sm">결과: {String(data)}</div>
+      )}
+    </div>
+  );
+}

--- a/src/features/room/join/JoinRoomButton.tsx
+++ b/src/features/room/join/JoinRoomButton.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+type Props = {
+  slug: string;
+};
+
+export default function JoinRoomButton({ slug }: Props) {
+  const router = useRouter();
+
+  return (
+    <button
+      className="border cursor-pointer"
+      onClick={() => router.push(`/room/${slug}`)}
+    >
+      방 입장하기
+    </button>
+  );
+}

--- a/src/features/user-profile/api/updateMe.ts
+++ b/src/features/user-profile/api/updateMe.ts
@@ -1,8 +1,7 @@
 import { axiosInstance } from "@/src/shared/api/axiosInstance";
 import type { User } from "@/src/entities/user/model/types";
 import type { UpdateMePayload } from "../model/types";
-
-type ApiResponse<T> = { result: T };
+import { ApiResponse } from "@/src/shared/api/types";
 
 export async function updateMe(payload: UpdateMePayload): Promise<User> {
   const { data } = await axiosInstance.patch<ApiResponse<User>>(

--- a/src/features/user-profile/hooks/useUpdateMe.ts
+++ b/src/features/user-profile/hooks/useUpdateMe.ts
@@ -2,15 +2,17 @@
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { updateMe } from "../api/updateMe";
-import { UpdateMePayload } from "../model/types";
+import type { UpdateMePayload } from "../model/types";
+import type { ApiError } from "@/src/shared/api/api-error";
+import type { User } from "@/src/entities/user/model/types"; // 너 프로젝트 User 타입 경로에 맞게
 
 export function useUpdateMe() {
   const qc = useQueryClient();
 
-  return useMutation({
-    mutationFn: (payload: UpdateMePayload) => updateMe(payload),
+  return useMutation<User, ApiError, UpdateMePayload>({
+    mutationFn: (payload) => updateMe(payload),
     onSuccess: async () => {
-      await qc.invalidateQueries({ queryKey: ["me"] }); // ✅ /me 재조회
+      await qc.invalidateQueries({ queryKey: ["me"] });
     },
   });
 }

--- a/src/features/user-profile/ui/NicknameEditForm.tsx
+++ b/src/features/user-profile/ui/NicknameEditForm.tsx
@@ -28,7 +28,11 @@ export default function NicknameEditForm() {
         disabled={isPending}
       />
 
-      <button type="submit" className="border px-3 py-1" disabled={isPending}>
+      <button
+        type="submit"
+        className="border px-3 py-1 cursor-pointer"
+        disabled={isPending}
+      >
         {isPending ? "변경 중..." : "변경하기"}
       </button>
 

--- a/src/features/user-profile/ui/NicknameEditForm.tsx
+++ b/src/features/user-profile/ui/NicknameEditForm.tsx
@@ -21,7 +21,7 @@ export default function NicknameEditForm() {
       <label className="block text-sm">변경할 닉네임 입력</label>
 
       <input
-        className="border px-2 py-1"
+        className="border px-2 py-1 text-black"
         value={nickname}
         onChange={(e) => setNickname(e.target.value)}
         placeholder="새 닉네임"
@@ -32,7 +32,11 @@ export default function NicknameEditForm() {
         {isPending ? "변경 중..." : "변경하기"}
       </button>
 
-      {error && <p className="text-sm text-red-600">변경 실패</p>}
+      {error && (
+        <p className="text-sm text-red-600">
+          닉네임 변경: ({error.status}) {error.message}
+        </p>
+      )}
     </form>
   );
 }

--- a/src/shared/api/api-error.ts
+++ b/src/shared/api/api-error.ts
@@ -1,5 +1,11 @@
 export class ApiError extends Error {
-  constructor(public status: number, message: string) {
-    super(message);
+  status: number;
+  code?: string;
+
+  constructor(args: { status: number; message: string; code?: string }) {
+    super(args.message);
+    this.name = "ApiError";
+    this.status = args.status;
+    this.code = args.code;
   }
 }

--- a/src/shared/api/axiosInstance.ts
+++ b/src/shared/api/axiosInstance.ts
@@ -15,11 +15,27 @@ axiosInstance.interceptors.response.use(
   (res) => res,
   (err) => {
     const status = err?.response?.status ?? 0;
+
+    const backendError = err?.response?.data?.error;
+    const backendStatus = backendError?.statusCode;
+    const backendCode = backendError?.code;
+    const backendMessage = backendError?.message;
+
     const message =
+      backendMessage ??
       err?.response?.data?.message ??
       err?.response?.data ??
       err?.message ??
       "Unknown error";
-    return Promise.reject(new ApiError(status, String(message)));
+
+    const finalStatus = backendStatus ?? status;
+
+    return Promise.reject(
+      new ApiError({
+        status: finalStatus,
+        message: String(message),
+        code: backendCode,
+      })
+    );
   }
 );

--- a/src/shared/api/parse-api-error.ts
+++ b/src/shared/api/parse-api-error.ts
@@ -1,0 +1,41 @@
+import axios from "axios";
+import { ApiError } from "./api-error";
+
+type BackendErrorBody = {
+  error: {
+    statusCode: number;
+    code: string;
+    message: string;
+  };
+};
+
+export function toApiError(err: unknown): ApiError {
+  // axios 에러인 경우 (백엔드 응답 파싱)
+  if (axios.isAxiosError(err)) {
+    const status = err.response?.status ?? 0;
+    const data = err.response?.data as BackendErrorBody | undefined;
+
+    const backend = data?.error;
+
+    // 백엔드 포맷이 있는 경우
+    if (backend?.statusCode && backend?.message) {
+      return new ApiError({
+        status: backend.statusCode,
+        code: backend.code,
+        message: backend.message,
+      });
+    }
+
+    // 백엔드 포맷이 없을 때 (nginx, html, 네트워크 등)
+    return new ApiError({
+      status,
+      message: err.message || "요청 중 오류가 발생했어요.",
+    });
+  }
+
+  // 그 외 알 수 없는 에러
+  return new ApiError({
+    status: 0,
+    message: "알 수 없는 오류가 발생했어요.",
+  });
+}

--- a/src/shared/api/types.ts
+++ b/src/shared/api/types.ts
@@ -1,0 +1,1 @@
+export type ApiResponse<T> = { result: T };


### PR DESCRIPTION
## Title
<!-- 예) feat: room header UI -->
feat(room): 방 생성/조회/태그 조회 API 및 React Query 훅 추가
## Summary
<!-- 무엇을 했는지 1~3줄로 요약 -->
- 방 생성(createRoom), 방 목록 조회(fetchRooms), 태그 목록 조회(fetchRoomTags) API 함수 추가

- React Query 기반 useCreateRoom/useRoomsQuery/useRoomTagsQuery 훅 구현 및 캐시 무효화(invalidate) 적용

- 기능 확인을 위한 테스트 UI(태그 렌더링, 방 목록 렌더링, 방 생성 폼) 추가



## Notes
<!-- 리뷰어가 알아야 할 점 / 고민한 점 / 추후 할 일 -->
- createRoom 응답이 boolean(result: true/false) 기준으로 구현되어 있어, 추후 방 id/slug 반환으로 바뀌면 생성 성공 후 room으로 이동 로직 추가 예정

- 태그 목록이 현재 서버에서 빈 배열로 내려오는 중


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 방 생성 UI 및 생성 후 해당 방으로 자동 이동
  * 방 목록 조회, 태그 표시 및 방 입장 버튼 추가
  * 로그인 상태 표시 컴포넌트 및 테스트용 UI 컴포넌트들 추가
  * 개별 방 페이지에서 경로(슬러그) 표시

* **버그 수정**
  * API 오류 파싱 개선으로 사용자용 오류 메시지 및 상태 정보 향상

* **스타일**
  * 전역 스타일 적용 및 버튼/입력에 커서 개선 등 상호작용성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->